### PR TITLE
Refactor: diminuindo padding

### DIFF
--- a/embeds/timeline/index.html
+++ b/embeds/timeline/index.html
@@ -200,7 +200,7 @@
 
       .description-wrapper {
         max-width: 43.5rem;
-        padding: 0 3rem;
+        padding: 0 1rem;
       }
 
       .description-date {


### PR DESCRIPTION
Diminuindo padding das informações, pois o fivenews adiciona um espaço na área do embed que acaba deixando a área mais apertada.